### PR TITLE
Re-use sail:install

### DIFF
--- a/resources/scripts/php74.sh
+++ b/resources/scripts/php74.sh
@@ -11,11 +11,9 @@ docker run --rm \
     -v $(pwd):/opt \
     -w /opt \
     laravelsail/php74-composer:latest \
-    laravel new {{ name }}
+    bash -c "laravel new {{ name }} && cd {{ name }} && php ./artisan sail:install"
 
 cd {{ name }}
-
-php ./artisan sail:install
 
 CYAN='\033[0;36m'
 LIGHT_CYAN='\033[1;36m'

--- a/resources/scripts/php80.sh
+++ b/resources/scripts/php80.sh
@@ -11,11 +11,9 @@ docker run --rm \
     -v $(pwd):/opt \
     -w /opt \
     laravelsail/php80-composer:latest \
-    laravel new {{ name }}
+    bash -c "laravel new {{ name }} && cd {{ name }} && php ./artisan sail:install"
 
 cd {{ name }}
-
-php ./artisan sail:install
 
 CYAN='\033[0;36m'
 LIGHT_CYAN='\033[1;36m'


### PR DESCRIPTION
This re-uses `php artisan sail:install` to install the `docker-compose.yml` file and set the env variables. This way we can remove the docker compose file from the base skeleton so we don't have to keep these two files in sync.

Also brought the `php74.sh` file in sync.