### PR TITLE
Git support

### DIFF
--- a/resources/scripts/php80.sh
+++ b/resources/scripts/php80.sh
@@ -15,6 +15,17 @@ docker run --rm \
 
 cd {{ name }}
 
+if {{ git }}; then
+    git init -q .
+    git add .
+    git commit -q -m "Set up a fresh Laravel app"
+fi
+
+if {{ github }}; then
+    gh repo create {{ name }} -y {{ githubFlags }}
+    git push -q -u origin main
+fi
+
 CYAN='\033[0;36m'
 LIGHT_CYAN='\033[1;36m'
 WHITE='\033[1;37m'

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,11 +16,22 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/{name}', function (Request $request, $name) {
     $services = $request->query('with', 'mysql,redis,meilisearch,mailhog,selenium');
+    $git = $request->query('git', false);
+    $github = $request->query('github', false);
 
-    $script = file_get_contents(resource_path('scripts/php80.sh'));
-
-    $script = str_replace('{{ name }}', $name, $script);
-    $script = str_replace('{{ services }}', $services, $script);
+    $script = str_replace([
+        '{{ name }}',
+        '{{ services }}',
+        '{{ git }}',
+        '{{ github }}',
+        '{{ githubFlags }}',
+    ], [
+        $name,
+        $services,
+        $git !== false || $github !== false ? 'true' : 'false',
+        $github !== false ? 'true' : 'false',
+        $github !== false && $github !== 'true' && $github !== null ? $github : '--private',
+    ], file_get_contents(resource_path('scripts/php80.sh')));
 
     return response($script, 200, ['Content-Type' => 'text/plain']);
 });


### PR DESCRIPTION
Provides Git support for the Laravel Sail server. Here's some examples:

Installs Git a repo: 

```bash
curl -s "https://laravel.build/example-app?git" | bash
```

Installs Git repo and creates GitHub repo: 

```bash
curl -s "https://laravel.build/example-app?github" | bash
```

Extra GitHub flags: 

```bash
curl -s "https://laravel.build/example-app?github=--public --team laravel" | bash
```

This expects both Git & the GitHub CLI to be properly installed on the developer's device.