### PR TITLE
Redirect homepage and handle invalid name

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@ Route::get('/{name}', function (Request $request, $name) {
     try {
         Validator::validate(['name' => $name], ['name' => 'string|alpha_dash']);
     } catch (ValidationException $e) {
-        return response('Invalid site name. Please only use alpha-numeric characters, dashes and underscores.', 400);
+        return response('Invalid site name. Please only use alpha-numeric characters, dashes, and underscores.', 400);
     }
 
     $php = $request->query('php', '81');

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,20 +3,16 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
+Route::redirect('/', 'https://laravel.com/docs', 302);
 
 Route::get('/{name}', function (Request $request, $name) {
-    Validator::validate(['name' => $name], ['name' => 'string|alpha_dash']);
+    try {
+        Validator::validate(['name' => $name], ['name' => 'string|alpha_dash']);
+    } catch (ValidationException) {
+        return response('Invalid site name. Please only use alpha-numeric characters, dashes and underscores.', 400);
+    }
 
     $php = $request->query('php', '81');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,7 +10,7 @@ Route::redirect('/', 'https://laravel.com/docs', 302);
 Route::get('/{name}', function (Request $request, $name) {
     try {
         Validator::validate(['name' => $name], ['name' => 'string|alpha_dash']);
-    } catch (ValidationException) {
+    } catch (ValidationException $e) {
         return response('Invalid site name. Please only use alpha-numeric characters, dashes and underscores.', 400);
     }
 

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -6,6 +6,11 @@ use Tests\TestCase;
 
 class SailServerTest extends TestCase
 {
+    public function test_the_homepage_redirects_to_the_laravel_docs()
+    {
+        $this->get('/')->assertRedirect('https://laravel.com/docs');
+    }
+
     public function test_it_can_return_the_sail_install_script()
     {
         $response = $this->get('/example-app');
@@ -29,5 +34,13 @@ class SailServerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee('bash -c "laravel new example-app && cd example-app && php ./artisan sail:install --with=postgres --devcontainer"', false);
+    }
+
+    public function test_it_does_not_accepts_domains_with_a_dot()
+    {
+        $response = $this->get('/foo.test');
+
+        $response->assertStatus(400);
+        $response->assertSee('Invalid site name. Please only use alpha-numeric characters, dashes and underscores.');
     }
 }


### PR DESCRIPTION
This PR does two things:

- Adds a redirect to the laravel docs for the homepage. Currently it throws an empty 404 page.
- Handle the validation exception and show a descriptive message to solve an infinite redirect loop issue

This is in response to https://github.com/laravel/framework/issues/39182. This will not solve the following issue the OP got:

```
bash: line 1: syntax error near unexpected token `newline'
bash: line 1: `<!DOCTYPE html>'
```

I have no idea how to solve that with the bash pipe we document. I'll send an additional PR to the docs to clarify which characters you can use.