### PR TITLE
laravel new project_name --git

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -11,7 +11,7 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "laravel new {{ name }} && cd {{ name }} && php ./artisan sail:install --with={{ services }} {{ devcontainer }}"
+    bash -c "laravel new {{ name }} {{ with_git }} && cd {{ name }} && php ./artisan sail:install --with={{ services }} {{ devcontainer }}"
 
 cd {{ name }}
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,13 +16,15 @@ Route::get('/{name}', function (Request $request, $name) {
 
     $php = $request->query('php', '81');
 
+    $with_git = $request->has('git') ? '--git' : '';
+
     $services = $request->query('with', 'mysql,redis,meilisearch,mailhog,selenium');
 
     $devcontainer = $request->has('devcontainer') ? '--devcontainer' : '';
 
     $script = str_replace(
-        ['{{ php }}', '{{ name }}', '{{ services }}', '{{ devcontainer }}'],
-        [$php, $name, $services, $devcontainer],
+        ['{{ php }}', '{{ name }}', '{{ with_git }}', '{{ services }}', '{{ devcontainer }}'],
+        [$php, $name, $with_git, $services, $devcontainer],
         file_get_contents(resource_path('scripts/php.sh'))
     );
 

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -17,7 +17,7 @@ class SailServerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee("laravelsail/php81-composer:latest");
-        $response->assertSee('bash -c "laravel new example-app && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailhog,selenium "', false);
+        $response->assertSee('bash -c "laravel new example-app  && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailhog,selenium "', false);
     }
 
     public function test_different_services_can_be_picked()
@@ -28,12 +28,20 @@ class SailServerTest extends TestCase
         $response->assertSee('php ./artisan sail:install --with=postgresql,redis,selenium');
     }
 
+    public function test_it_adds_git_upon_request()
+    {
+        $response = $this->get('/example-app?with=postgres&git');
+
+        $response->assertStatus(200);
+        $response->assertSee('bash -c "laravel new example-app --git && cd example-app && php ./artisan sail:install --with=postgres "', false);
+    }
+
     public function test_it_adds_the_devcontainer_upon_request()
     {
         $response = $this->get('/example-app?with=postgres&devcontainer');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "laravel new example-app && cd example-app && php ./artisan sail:install --with=postgres --devcontainer"', false);
+        $response->assertSee('bash -c "laravel new example-app  && cd example-app && php ./artisan sail:install --with=postgres --devcontainer"', false);
     }
 
     public function test_it_does_not_accepts_domains_with_a_dot()


### PR DESCRIPTION
This merge request implements the feature request from https://github.com/laravel/installer/issues/224 .

If the `git` parameter is passed then `laravel new project_name --git` is called instead of `laravel new project_name`, initializing the git repository for the project (as documented in https://laravel.com/docs/9.x#the-laravel-installer ).