### PR TITLE
Build and pull sail services on installation

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -11,9 +11,12 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "laravel new {{ name }} && cd {{ name }} && php ./artisan sail:install --with={{ services }} {{ devcontainer }}"
+    bash -c "laravel new {{ name }} && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
 
 cd {{ name }}
+
+./vendor/bin/sail pull {{ services }}
+./vendor/bin/sail build
 
 CYAN='\033[0;36m'
 LIGHT_CYAN='\033[1;36m'

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,13 +16,15 @@ Route::get('/{name}', function (Request $request, $name) {
 
     $php = $request->query('php', '81');
 
-    $services = $request->query('with', 'mysql,redis,meilisearch,mailhog,selenium');
+    $with = $request->query('with', 'mysql,redis,meilisearch,mailhog,selenium');
+
+    $services = str_replace(',', ' ', $with);
 
     $devcontainer = $request->has('devcontainer') ? '--devcontainer' : '';
 
     $script = str_replace(
-        ['{{ php }}', '{{ name }}', '{{ services }}', '{{ devcontainer }}'],
-        [$php, $name, $services, $devcontainer],
+        ['{{ php }}', '{{ name }}', '{{ with }}', '{{ devcontainer }}', '{{ services }}'],
+        [$php, $name, $with, $devcontainer, $services],
         file_get_contents(resource_path('scripts/php.sh'))
     );
 


### PR DESCRIPTION
In https://github.com/laravel/sail/pull/467 I made the `sail:install` command automatically build and pull the required services so that the first `sail up` can start serving immediately.

However, when installing Laravel Sail via `laravel.build`, the `sail:install` command is run _inside_ a temporary container where it cannot run the docker commands :woman_facepalming: 

I have created https://github.com/laravel/sail/pull/468 that prevents `sail:install` from attempting to run the docker commands when docker is not available.

This PR adds that same functionality to `laravel.build` so that the first `sail up` starts serving immediately, no matter how you install Laravel Sail.