### PR TITLE
Always pull the latest install image

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -8,6 +8,7 @@ if [ $? -ne 0 ]; then
 fi
 
 docker run --rm \
+    --pull=always \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \


### PR DESCRIPTION
Recently the `laravelsail/*` images were updated on Docker hub to include the latest version of the `laravel` install command.

However, when using `laravel.build` to start a new app, I was still getting an old version of the installer. This is because `docker run` by default only pulls the image if it is missing ([ref](https://docs.docker.com/engine/reference/commandline/run/#-set-the-pull-policy---pull)).

This PR updates the install script to specify a pull policy of "always" to ensure that the latest version of the install image is used. If the user already has the latest version, it won't be re-downloaded and they will just see the following message:

![image](https://user-images.githubusercontent.com/4977161/188800522-f1a390d1-43bb-425f-b524-c339c9b83dbf.png)