### PR TITLE
Update WHITE to BOLD to support light terminals

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -21,18 +21,18 @@ cd {{ name }}
 
 CYAN='\033[0;36m'
 LIGHT_CYAN='\033[1;36m'
-WHITE='\033[1;37m'
+BOLD='\033[1m'
 NC='\033[0m'
 
 echo ""
 
 if sudo -n true 2>/dev/null; then
     sudo chown -R $USER: .
-    echo -e "${WHITE}Get started with:${NC} cd {{ name }} && ./vendor/bin/sail up"
+    echo -e "${BOLD}Get started with:${NC} cd {{ name }} && ./vendor/bin/sail up"
 else
-    echo -e "${WHITE}Please provide your password so we can make some final adjustments to your application's permissions.${NC}"
+    echo -e "${BOLD}Please provide your password so we can make some final adjustments to your application's permissions.${NC}"
     echo ""
     sudo chown -R $USER: .
     echo ""
-    echo -e "${WHITE}Thank you! We hope you build something incredible. Dive in with:${NC} cd {{ name }} && ./vendor/bin/sail up"
+    echo -e "${BOLD}Thank you! We hope you build something incredible. Dive in with:${NC} cd {{ name }} && ./vendor/bin/sail up"
 fi


### PR DESCRIPTION
Currently the build script prints texts in a white color. This makes it very hard to read in light terminal schemes (I've highlighted part of it to make it clear that there is text):
![image](https://user-images.githubusercontent.com/6287093/196537263-427f056c-8a26-484f-8458-d34fdaa7d005.png)

This PR changes that to just use a bold font with the corresponding default text color.