### PR TITLE
Replace mailhog with mailpit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,12 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.3
+          php-version: 8.0
           extensions: dom, curl, libxml, mbstring, zip, pcntl
           coverage: none
 
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction
-
-      - name: Execute tests
-        run: vendor/bin/phpunit --verbose
 
       - name: Execute tests
         run: vendor/bin/phpunit --verbose

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,7 +16,7 @@ Route::get('/{name}', function (Request $request, $name) {
 
     $php = $request->query('php', '82');
 
-    $with = $request->query('with', 'mysql,redis,meilisearch,mailhog,selenium');
+    $with = $request->query('with', 'mysql,redis,meilisearch,mailpit,selenium');
 
     $services = str_replace(',', ' ', $with);
 

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -17,7 +17,7 @@ class SailServerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee("laravelsail/php82-composer:latest");
-        $response->assertSee('bash -c "laravel new example-app && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailhog,selenium "', false);
+        $response->assertSee('bash -c "laravel new example-app && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 
     public function test_different_services_can_be_picked()


### PR DESCRIPTION
### Fixed

- After replacing `mailhog` with `mailpit` at https://github.com/laravel/sail/pull/533, the default script generated by the Sail Server is still returning mentioning `mailhog`

---

Example: https://laravel.build/turbo-chirper