### PR TITLE
Remove warning when using with=none

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -16,7 +16,7 @@ docker run --rm \
 
 cd {{ name }}
 
-./vendor/bin/sail pull {{ services }}
+{{ pull }} {{ services }}
 ./vendor/bin/sail build
 
 CYAN='\033[0;36m'

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,13 +18,21 @@ Route::get('/{name}', function (Request $request, $name) {
 
     $with = $request->query('with', 'mysql,redis,meilisearch,mailpit,selenium');
 
-    $services = str_replace(',', ' ', $with);
+    if ($with === 'none') {
+        $pull = '';
+
+        $services = '';
+    } else {
+        $pull = './vendor/bin/sail pull';
+
+        $services = str_replace(',', ' ', $with);
+    }
 
     $devcontainer = $request->has('devcontainer') ? '--devcontainer' : '';
 
     $script = str_replace(
-        ['{{ php }}', '{{ name }}', '{{ with }}', '{{ devcontainer }}', '{{ services }}'],
-        [$php, $name, $with, $devcontainer, $services],
+        ['{{ php }}', '{{ name }}', '{{ with }}', '{{ devcontainer }}', '{{ pull }}', '{{ services }}'],
+        [$php, $name, $with, $devcontainer, $pull, $services],
         file_get_contents(resource_path('scripts/php.sh'))
     );
 


### PR DESCRIPTION
Currently, `https://laravel.build/example-app?with=none` generates a script that includes the lines:

`php ./artisan sail:install --with=none`
and
`./vendor/bin/sail pull none`

and hence the warning `no such service: none` appears when installing using:
`curl -s "https://laravel.build/example-app?with=none" | bash`.

This pull request improves consistency and confusion.