### PR TITLE
Allow build with no additional services

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -16,7 +16,7 @@ docker run --rm \
 
 cd {{ name }}
 
-# Allow build with no additional services
+# Allow build with no additional services..
 if [ "{{ services }}" == "none" ]; then
     ./vendor/bin/sail build
 else

--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -16,8 +16,13 @@ docker run --rm \
 
 cd {{ name }}
 
-./vendor/bin/sail pull {{ services }}
-./vendor/bin/sail build
+# Allow build with no additional services
+if [ "{{ services }}" == "none" ]; then
+    ./vendor/bin/sail build
+else
+    ./vendor/bin/sail pull {{ services }}
+    ./vendor/bin/sail build
+fi
 
 CYAN='\033[0;36m'
 LIGHT_CYAN='\033[1;36m'

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,7 +41,7 @@ Route::get('/{name}', function (Request $request, $name) {
                 'with.*' => [
                     'required',
                     'string',
-                    count($with) === 1 && in_array("none", $with) ? Rule::in(['none']) : Rule::in($availableServices)
+                    count($with) === 1 && in_array('none', $with) ? Rule::in(['none']) : Rule::in($availableServices)
                 ],
             ]
         );

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,12 +38,16 @@ Route::get('/{name}', function (Request $request, $name) {
                 'name' => 'string|alpha_dash',
                 'php' => ['string', Rule::in(['74', '80', '81', '82'])],
                 'with' => 'array',
-                'with.*' => ['required', 'string', Rule::in($availableServices)],
+                'with.*' => [
+                    'required',
+                    'string',
+                    count($with) === 1 && in_array("none", $with) ? Rule::in(['none']) : Rule::in($availableServices)
+                ],
             ]
         );
     } catch (ValidationException $e) {
         $errors = Arr::undot($e->errors());
-        
+
         if (array_key_exists('name', $errors)) {
             return response('Invalid site name. Please only use alpha-numeric characters, dashes, and underscores.', 400);
         }
@@ -53,7 +57,7 @@ Route::get('/{name}', function (Request $request, $name) {
         }
 
         if (array_key_exists('with', $errors)) {
-            return response('Invalid service name. Please provide one or more of the supported services ('.implode(', ', $availableServices).').', 400);
+            return response('Invalid service name. Please provide one or more of the supported services ('.implode(', ', $availableServices).') or "none".', 400);
         }
     }
 

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -36,6 +36,14 @@ class SailServerTest extends TestCase
         $response->assertSee('php ./artisan sail:install --with=pgsql,redis,selenium');
     }
 
+    public function test_no_services_can_be_picked()
+    {
+        $response = $this->get('/example-app?with=none');
+
+        $response->assertStatus(200);
+        $response->assertSee('php ./artisan sail:install --with=none');
+    }
+
     public function test_it_removes_duplicated_valid_services()
     {
         $response = $this->get('/example-app?with=redis,redis');
@@ -81,7 +89,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi).');
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_invalid_services()
@@ -89,6 +97,14 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,invalid_service_name');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi).');
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+    }
+
+    public function test_it_does_not_accept_none_with_other_services()
+    {
+        $response = $this->get('/example-app?with=none,redis');
+
+        $response->assertStatus(400);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
     }
 }


### PR DESCRIPTION
Allows for the use of `--with=none` option e.g. `php ./artisan sail:install --with=none`. Please see: https://github.com/laravel/sail/pull/495 & [this](https://github.com/laravel/sail/blob/e23cebe7bcfc39223e711623e684fdcf73320067/src/Console/InstallCommand.php#L37).

PR to Update Sail Server documentation: https://github.com/laravel/docs/pull/8831 