### PR TITLE
Revert default back to PHP 8.2 due to issues with 8.3

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,7 +23,7 @@ Route::get('/{name}', function (Request $request, $name) {
         'soketi',
     ];
 
-    $php = $request->query('php', '83');
+    $php = $request->query('php', '82');
 
     $with = array_unique(explode(',', $request->query('with', 'mysql,redis,meilisearch,mailpit,selenium')));
 

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -16,7 +16,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app');
 
         $response->assertStatus(200);
-        $response->assertSee("laravelsail/php83-composer:latest");
+        $response->assertSee("laravelsail/php82-composer:latest");
         $response->assertSee('bash -c "laravel new example-app && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 


### PR DESCRIPTION
See: https://github.com/laravel/installer/issues/297

No idea why this is happening, however it currently causes issues. Maybe it's just build and push a new update to the php sail image 8.3 but I'm not sure I can do that.

Reproduce error with 8.3:

```
docker run --rm \
    --pull=always \
    -v "$(pwd)":/opt \
    -w /opt \
    laravelsail/php83-composer:latest \
    bash -c "laravel new octane-frankenphp && cd octane-frankenphp && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "
```

Reproduce success with 8.2:

```
docker run --rm \
    --pull=always \
    -v "$(pwd)":/opt \
    -w /opt \
    laravelsail/php82-composer:latest \
    bash -c "laravel new octane-frankenphp && cd octane-frankenphp && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "
```