### PR TITLE
Fix mariadb services

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,8 @@ Route::get('/{name}', function (Request $request, $name) {
         'mysql',
         'pgsql',
         'mariadb',
+        'mariadb10',
+        'mariadb11',
         'redis',
         'memcached',
         'meilisearch',
@@ -27,6 +29,11 @@ Route::get('/{name}', function (Request $request, $name) {
     $php = $request->query('php', '83');
 
     $with = array_unique(explode(',', $request->query('with', 'mysql,redis,meilisearch,mailpit,selenium')));
+
+    if(in_array('mariadb', $with)) {
+        $with = array_diff($with, ['mariadb']);
+        $with[] = 'mariadb11';
+    }
 
     try {
         Validator::validate(

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -89,7 +89,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_invalid_services()
@@ -97,7 +97,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,invalid_service_name');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_none_with_other_services()
@@ -105,6 +105,6 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=none,redis');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
     }
 }

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -89,7 +89,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_invalid_services()
@@ -97,7 +97,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,invalid_service_name');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_none_with_other_services()
@@ -105,6 +105,6 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=none,redis');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mariadb10, mariadb11, redis, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/laravel/sail/issues/701

After renaming the sail services for mariadb in `mariadb10` and `mariadb` the installation with the query parameter is currently not possible.

This PR allows `mariadb10` and `mariadb11`, as well as replacing `mariadb` with `mariadb11`