### PR TITLE
Make Sail Server compliant with Laravel 12

### DIFF
--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -12,7 +12,7 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "composer global update laravel/installer && laravel new {{ name }} {{ frontend }} {{ authProvider }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
+    bash -c "composer global update laravel/installer && laravel new {{ name }} {{ frontend }} {{ authProvider }} {{ testFramework }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
 
 cd {{ name }}
 

--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -12,7 +12,7 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "laravel new {{ name }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
+    bash -c "composer global update laravel/installer && laravel new {{ name }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
 
 cd {{ name }}
 

--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -12,7 +12,7 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "composer global update laravel/installer && laravel new {{ name }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
+    bash -c "composer global update laravel/installer && laravel new {{ name }} {{ frontend }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
 
 cd {{ name }}
 

--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -42,11 +42,11 @@ fi
 
 if $SUDO -n true 2>/dev/null; then
     $SUDO chown -R $USER: .
-    echo -e "${BOLD}Get started with:${NC} cd {{ name }} && ./vendor/bin/sail up"
+    echo -e "${BOLD}Get started with:${NC} cd {{ name }} && ./vendor/bin/sail up && ./vendor/bin/sail npm install && ./vendor/bin/sail npm run dev"
 else
     echo -e "${BOLD}Please provide your password so we can make some final adjustments to your application's permissions.${NC}"
     echo ""
     $SUDO chown -R $USER: .
     echo ""
-    echo -e "${BOLD}Thank you! We hope you build something incredible. Dive in with:${NC} cd {{ name }} && ./vendor/bin/sail up"
+    echo -e "${BOLD}Thank you! We hope you build something incredible. Dive in with:${NC} cd {{ name }} && ./vendor/bin/sail up && ./vendor/bin/sail npm install && ./vendor/bin/sail npm run dev"
 fi

--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -12,7 +12,7 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "composer global update laravel/installer && laravel new {{ name }} {{ frontend }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
+    bash -c "composer global update laravel/installer && laravel new {{ name }} {{ frontend }} {{ authProvider }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
 
 cd {{ name }}
 

--- a/resources/scripts/php.sh
+++ b/resources/scripts/php.sh
@@ -12,7 +12,7 @@ docker run --rm \
     -v "$(pwd)":/opt \
     -w /opt \
     laravelsail/php{{ php }}-composer:latest \
-    bash -c "composer global update laravel/installer && laravel new {{ name }} {{ frontend }} {{ authProvider }} {{ testFramework }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
+    bash -c "composer global require laravel/installer && rm /usr/bin/laravel && ln -s ~/.composer/vendor/bin/laravel /usr/bin/laravel && laravel new {{ name }} {{ frontend }} {{ authProvider }} {{ testFramework }} --no-interaction && cd {{ name }} && php ./artisan sail:install --with={{ with }} {{ devcontainer }}"
 
 cd {{ name }}
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,7 @@ Route::get('/{name}', function (Request $request, $name) {
         'mailpit',
         'selenium',
         'soketi',
+        'mongodb',
     ];
 
     $availableFrontends = [

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ Route::get('/{name}', function (Request $request, $name) {
         'mysql',
         'pgsql',
         'mariadb',
+        'mongodb',
         'redis',
         'valkey',
         'memcached',
@@ -23,7 +24,6 @@ Route::get('/{name}', function (Request $request, $name) {
         'mailpit',
         'selenium',
         'soketi',
-        'mongodb',
     ];
 
     $availableFrontends = [

--- a/tests/Feature/Laravel12AuthTest.php
+++ b/tests/Feature/Laravel12AuthTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class Laravel12AuthTest extends TestCase
+{
+    public function test_it_accepts_no_authentication()
+    {
+        $response = $this->get('/example-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --no-interaction', false);
+    }
+
+    public function test_it_accepts_auth_workos()
+    {
+        $response = $this->get('/example-app?auth=workos');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --workos --no-interaction', false);
+    }
+    
+    public function test_it_does_not_accept_invalid_auth()
+    {
+        $response = $this->get('/example-app?auth=invalid');
+
+        $response->assertStatus(400);
+        $response->assertSee('Invalid Authentication Provider. Please provide one supported Authentication Provider (workos) or leave it empty (it will use laravel).');
+    }
+}

--- a/tests/Feature/Laravel12AuthTest.php
+++ b/tests/Feature/Laravel12AuthTest.php
@@ -13,7 +13,7 @@ class Laravel12AuthTest extends TestCase
         $response = $this->get('/example-app');
 
         $response->assertStatus(200);
-        $response->assertSee('laravel new example-app --livewire --no-interaction', false);
+        $response->assertSee('laravel new example-app --livewire --pest --no-interaction', false);
     }
 
     public function test_it_accepts_auth_workos()
@@ -21,7 +21,7 @@ class Laravel12AuthTest extends TestCase
         $response = $this->get('/example-app?auth=workos');
 
         $response->assertStatus(200);
-        $response->assertSee('laravel new example-app --livewire --workos --no-interaction', false);
+        $response->assertSee('laravel new example-app --livewire --workos --pest --no-interaction', false);
     }
     
     public function test_it_does_not_accept_invalid_auth()

--- a/tests/Feature/Laravel12FrontendTest.php
+++ b/tests/Feature/Laravel12FrontendTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class Laravel12FrontendTest extends TestCase
+{
+    public function test_it_accepts_no_frontend_and_uses_livewire()
+    {
+        $response = $this->get('/example-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --pest --no-interaction', false);
+    }
+
+    public function test_it_accepts_frontend_livewire()
+    {
+        $response = $this->get('/example-app?frontend=livewire');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --pest --no-interaction', false);
+    }
+
+    public function test_it_accepts_frontend_react()
+    {
+        $response = $this->get('/example-app?frontend=react');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --react --pest --no-interaction', false);
+    }
+
+    public function test_it_accepts_frontend_vue()
+    {
+        $response = $this->get('/example-app?frontend=vue');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --vue --pest --no-interaction', false);
+    }
+    
+    public function test_it_accepts_frontend_livewire_class_components()
+    {
+        $response = $this->get('/example-app?frontend=livewire-class-components');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire-class-components --pest --no-interaction', false);
+    }
+    
+    public function test_it_does_not_accept_invalid_frontend()
+    {
+        $response = $this->get('/example-app?frontend=invalid');
+
+        $response->assertStatus(400);
+        $response->assertSee('Invalid frontend. Please provide one supported frontend (react, vue, livewire, livewire-class-components) or leave it empty (it will use livewire).');
+    }
+}

--- a/tests/Feature/Laravel12Test.php
+++ b/tests/Feature/Laravel12Test.php
@@ -13,6 +13,6 @@ class Laravel12Test extends TestCase
         $response = $this->get('/example-app');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 }

--- a/tests/Feature/Laravel12Test.php
+++ b/tests/Feature/Laravel12Test.php
@@ -13,6 +13,6 @@ class Laravel12Test extends TestCase
         $response = $this->get('/example-app');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+        $response->assertSee('bash -c "composer global require laravel/installer && rm /usr/bin/laravel && ln -s ~/.composer/vendor/bin/laravel /usr/bin/laravel && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 }

--- a/tests/Feature/Laravel12Test.php
+++ b/tests/Feature/Laravel12Test.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class Laravel12Test extends TestCase
+{
+    public function test_it_should_update_laravel_installer()
+    {
+        $response = $this->get('/example-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+    }
+}

--- a/tests/Feature/Laravel12Test.php
+++ b/tests/Feature/Laravel12Test.php
@@ -13,6 +13,6 @@ class Laravel12Test extends TestCase
         $response = $this->get('/example-app');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 }

--- a/tests/Feature/Laravel12TestFrameworkTest.php
+++ b/tests/Feature/Laravel12TestFrameworkTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class Laravel12TestFrameworkTest extends TestCase
+{
+    public function test_it_accepts_no_authentication_and_uses_pest()
+    {
+        $response = $this->get('/example-app');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --pest --no-interaction', false);
+    }
+
+    public function test_it_accepts_test_pest()
+    {
+        $response = $this->get('/example-app?tests=pest');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --pest --no-interaction', false);
+    }
+
+    public function test_it_accepts_test_phpunit()
+    {
+        $response = $this->get('/example-app?tests=phpunit');
+
+        $response->assertStatus(200);
+        $response->assertSee('laravel new example-app --livewire --phpunit --no-interaction', false);
+    }
+    
+    public function test_it_does_not_accept_invalid_test()
+    {
+        $response = $this->get('/example-app?tests=invalid');
+
+        $response->assertStatus(400);
+        $response->assertSee('Invalid testing framework. Please provide one supported testing framework (phpunit, pest) or leave it empty (it will use pest).');
+    }
+}

--- a/tests/Feature/Laravel12TestFrameworkTest.php
+++ b/tests/Feature/Laravel12TestFrameworkTest.php
@@ -8,7 +8,7 @@ use Tests\TestCase;
 
 class Laravel12TestFrameworkTest extends TestCase
 {
-    public function test_it_accepts_no_authentication_and_uses_pest()
+    public function test_it_accepts_no_test_and_uses_pest()
     {
         $response = $this->get('/example-app');
 

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -17,7 +17,7 @@ class SailServerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee("laravelsail/php84-composer:latest");
-        $response->assertSee('bash -c "laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 
     public function test_different_php_versions_can_be_picked()
@@ -49,7 +49,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,redis');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=redis "', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=redis "', false);
     }
 
     public function test_it_adds_the_devcontainer_upon_request()
@@ -57,7 +57,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=pgsql&devcontainer');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=pgsql --devcontainer"', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=pgsql --devcontainer"', false);
     }
 
     public function test_it_does_not_accepts_domains_with_a_dot()

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -89,7 +89,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, valkey, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mongodb, redis, valkey, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_invalid_services()
@@ -97,7 +97,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,invalid_service_name');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, valkey, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mongodb, redis, valkey, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
     }
 
     public function test_it_does_not_accept_none_with_other_services()
@@ -105,6 +105,6 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=none,redis');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, redis, valkey, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
+        $response->assertSee('Invalid service name. Please provide one or more of the supported services (mysql, pgsql, mariadb, mongodb, redis, valkey, memcached, meilisearch, typesense, minio, mailpit, selenium, soketi) or "none".', false);
     }
 }

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -17,7 +17,7 @@ class SailServerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee("laravelsail/php84-composer:latest");
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+        $response->assertSee('bash -c "composer global require laravel/installer && rm /usr/bin/laravel && ln -s ~/.composer/vendor/bin/laravel /usr/bin/laravel && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 
     public function test_different_php_versions_can_be_picked()
@@ -49,7 +49,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,redis');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=redis "', false);
+        $response->assertSee('bash -c "composer global require laravel/installer && rm /usr/bin/laravel && ln -s ~/.composer/vendor/bin/laravel /usr/bin/laravel && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=redis "', false);
     }
 
     public function test_it_adds_the_devcontainer_upon_request()
@@ -57,7 +57,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=pgsql&devcontainer');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=pgsql --devcontainer"', false);
+        $response->assertSee('bash -c "composer global require laravel/installer && rm /usr/bin/laravel && ln -s ~/.composer/vendor/bin/laravel /usr/bin/laravel && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=pgsql --devcontainer"', false);
     }
 
     public function test_it_does_not_accepts_domains_with_a_dot()

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -17,7 +17,7 @@ class SailServerTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertSee("laravelsail/php84-composer:latest");
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 
     public function test_different_php_versions_can_be_picked()
@@ -49,7 +49,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=redis,redis');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=redis "', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=redis "', false);
     }
 
     public function test_it_adds_the_devcontainer_upon_request()
@@ -57,7 +57,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?with=pgsql&devcontainer');
 
         $response->assertStatus(200);
-        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --no-interaction && cd example-app && php ./artisan sail:install --with=pgsql --devcontainer"', false);
+        $response->assertSee('bash -c "composer global update laravel/installer && laravel new example-app --livewire --pest --no-interaction && cd example-app && php ./artisan sail:install --with=pgsql --devcontainer"', false);
     }
 
     public function test_it_does_not_accepts_domains_with_a_dot()


### PR DESCRIPTION
# Description
Make Sail Server compliant with Laravel 12

# Steps to Run
Updated Sail docs (check last item of Implement/Fixes below)

## Neccesary checkmarks:
    [x] All Tests are Passing
    [x] The code will run locally

## Type of change
    [x] New feature
    [] Bug Fix

## Implements/Fixes:
- Enable Sail Server to run Laravel 12
- Enable Service `mongodb`
- Allow user to choose Starter Kit: `react`, `vue`, `livewire` or`livewire-class-components`
- Allow user to choose `workos` Authentication Provider
- Allow User to choose Testing Framework `phpunit` or `pest`
- Docs Updated [PR](https://github.com/laravel/docs/pull/10331)

## Check the correct boxes
    [x] This broke nothing
    [] This broke some stuff
    [] This broke everything

## Testing Changes
    [] No Tests have been changed
    [x] Some Tests have been changed
    [] All of the Tests have been changed(Please describe what in the world happened)

## Checklist:
    [x] My code has no unused/commented out code
    [x] I have reviewed my code
    [x] I have commented my code, particularly in hard-to-understand areas
    [x] I have fully tested my code

## New Tests
- tests/Feature/Laravel12Test.php
- tests/Feature/Laravel12FrontendTest.php
- tests/Feature/Laravel12AuthTest.php
- tests/Feature/Laravel12TestFrameworkTest.php

## Updated Tests
- tests/Feature/SailServerTest.php