### PR TITLE
Revert default PHP version to 8.4

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -28,7 +28,7 @@ Route::get('/{name}', function (Request $request, $name) {
         'soketi',
     ];
 
-    $php = $request->query('php', '85');
+    $php = $request->query('php', '84');
 
     $with = array_unique(explode(',', $request->query('with', 'mysql,redis,meilisearch,mailpit,selenium')));
 
@@ -41,7 +41,7 @@ Route::get('/{name}', function (Request $request, $name) {
             ],
             [
                 'name' => 'string|alpha_dash',
-                'php' => ['string', Rule::in(['74', '80', '81', '82', '83', '84', '85'])],
+                'php' => ['string', Rule::in(['74', '80', '81', '82', '83', '84'])],
                 'with' => 'array',
                 'with.*' => [
                     'required',
@@ -58,7 +58,7 @@ Route::get('/{name}', function (Request $request, $name) {
         }
 
         if (array_key_exists('php', $errors)) {
-            return response('Invalid PHP version. Please specify a supported version (74, 80, 81, 82, 83, 84 or 85).', 400);
+            return response('Invalid PHP version. Please specify a supported version (74, 80, 81, 82, 83, or 84).', 400);
         }
 
         if (array_key_exists('with', $errors)) {

--- a/tests/Feature/SailServerTest.php
+++ b/tests/Feature/SailServerTest.php
@@ -16,7 +16,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app');
 
         $response->assertStatus(200);
-        $response->assertSee("laravelsail/php85-composer:latest");
+        $response->assertSee("laravelsail/php84-composer:latest");
         $response->assertSee('bash -c "laravel new example-app --no-interaction && cd example-app && composer show laravel/sail 2>/dev/null || composer require laravel/sail --dev && php ./artisan sail:install --with=mysql,redis,meilisearch,mailpit,selenium "', false);
     }
 
@@ -73,7 +73,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?php');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid PHP version. Please specify a supported version (74, 80, 81, 82, 83, 84 or 85).');
+        $response->assertSee('Invalid PHP version. Please specify a supported version (74, 80, 81, 82, 83, or 84).');
     }
 
     public function test_it_does_not_accept_invalid_php_versions()
@@ -81,7 +81,7 @@ class SailServerTest extends TestCase
         $response = $this->get('/example-app?php=1000');
 
         $response->assertStatus(400);
-        $response->assertSee('Invalid PHP version. Please specify a supported version (74, 80, 81, 82, 83, 84 or 85).');
+        $response->assertSee('Invalid PHP version. Please specify a supported version (74, 80, 81, 82, 83, or 84).');
     }
 
     public function test_it_does_not_accept_empty_with_query_when_present()


### PR DESCRIPTION
The default PHP version was bumped to 8.5 in #34, but the
laravelsail/php85-composer image has not been published to Docker Hub.
As a result the install script served by laravel.build fails to pull
the image and breaks for anyone who does not explicitly pass ?php=84.

Refs laravel/sail#864